### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gradio==3.24.1
+gradio==3.36.1
 hupper==1.11
 langchain==0.0.135
 openai==0.27.2


### PR DESCRIPTION
gradio v3.24.1 gives error below. 3.36.1 resolves it 

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "somepath\langchain_gradio\lib\site-packages\hupper\ipc.py", line 319, in spawn_main
    func(**kwargs)
  File "somepath\langchain_gradio\lib\site-packages\hupper\worker.py", line 283, in worker_main
    func(*spec_args, **spec_kwargs)
  File "somepath\chatbot.py", line 76, in main
    iface = gr.Interface(
  File "somepath\langchain_gradio\lib\site-packages\gradio\interface.py", line 403, in __init__
    with self:
  File "somepath\langchain_gradio\lib\site-packages\gradio\blocks.py", line 1200, in __exit__
    self.config = self.get_config_file()
  File "somepath\langchain_gradio\lib\site-packages\gradio\blocks.py", line 1176, in get_config_file
    "input": list(block.input_api_info()),  # type: ignore
  File "somepath\langchain_gradio\lib\site-packages\gradio_client\serializing.py", line 42, in input_api_info
    return (api_info["serialized_input"][0], api_info["serialized_input"][1])
KeyError: 'serialized_input'